### PR TITLE
feat(ml): implement graceful fallback for role prediction and LSTM in…

### DIFF
--- a/backend/ml_inference.py
+++ b/backend/ml_inference.py
@@ -26,6 +26,11 @@ logger = logging.getLogger("ml_inference")
 MAX_SKILLS = 20   # sequence length fed to LSTM branch A
 EMB_DIM    = 384  # all-MiniLM-L6-v2 embedding dimension
 
+# Minimum role-predictor confidence to trust the ML output.
+# Below this threshold the worker falls back to NLP role matching and the
+# predicted_role field is set to "Auto Detect" in the stored result.
+ROLE_CONFIDENCE_THRESHOLD: float = 0.60
+
 
 # ── Internal helpers ──────────────────────────────────────────────────────────
 
@@ -89,14 +94,34 @@ def predict_role(
             for i in top_indices
         ]
 
+        confidence = round(float(proba[pred_idx]), 4)
+
+        # ── Confidence threshold gate ────────────────────────────────
+        if confidence < ROLE_CONFIDENCE_THRESHOLD:
+            logger.warning(
+                "predict_role: confidence %.4f < threshold %.2f for role '%s' – "
+                "returning source=low_confidence so worker falls back to NLP",
+                confidence, ROLE_CONFIDENCE_THRESHOLD, role_labels[pred_idx],
+            )
+            return {
+                "predicted_role": role_labels[pred_idx],   # kept for logging
+                "confidence":     confidence,
+                "top_roles":      top_roles,
+                "source":         "low_confidence",
+            }
+
         return {
             "predicted_role": role_labels[pred_idx],
-            "confidence":     round(float(proba[pred_idx]), 4),
+            "confidence":     confidence,
             "top_roles":      top_roles,
             "source":         "ml",
         }
     except Exception as exc:
-        logger.error("predict_role error: %s", exc)
+        logger.error(
+            "predict_role error (%s): %s",
+            type(exc).__name__, exc,
+            exc_info=True,
+        )
         return {"predicted_role": None, "confidence": 0.0, "top_roles": [], "source": "fallback"}
 
 
@@ -172,7 +197,11 @@ def predict_missing_skills(
             "source":         "ml",
         }
     except Exception as exc:
-        logger.error("predict_missing_skills error: %s", exc)
+        logger.error(
+            "predict_missing_skills error (%s) for role '%s': %s",
+            type(exc).__name__, target_role, exc,
+            exc_info=True,
+        )
         return {"missing_skills": [], "confidences": {}, "source": "fallback"}
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -190,8 +190,24 @@ class AnalysisResult(BaseModel):
                                                            description="ML artifact version used")
 
     # ── Provenance ────────────────────────────────────────────────────
-    ml_role_source:        Optional[str]           = None
-    ml_missing_source:     Optional[str]           = None
+    ml_role_source:        Optional[str]           = Field(
+        default=None,
+        description=(
+            "Origin of the role prediction. "
+            "'ml' = high-confidence Random Forest; "
+            "'low_confidence' = RF below 0.60 threshold, NLP used instead; "
+            "'fallback' = model file missing or exception raised."
+        ),
+    )
+    ml_missing_source:     Optional[str]           = Field(
+        default=None,
+        description=(
+            "Origin of the missing-skills list. "
+            "'ml' = LSTM inference; "
+            "'static_lookup' = LSTM unavailable, rule-based table used; "
+            "'fallback' = LSTM exception or bundle missing."
+        ),
+    )
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/backend/tests/test_ml_fallback.py
+++ b/backend/tests/test_ml_fallback.py
@@ -1,0 +1,338 @@
+"""
+tests/test_ml_fallback.py
+=========================
+Unit tests for the graceful ML fallback logic.
+
+All three failure modes are covered:
+  1. Role-predictor confidence < 0.60  →  source="low_confidence"
+  2. Model file missing (bundle=None)  →  source="fallback" for both functions
+  3. LSTM inference raises exception   →  source="fallback", empty skill list
+
+No real models or MongoDB connection are required; all heavy objects are mocked.
+
+Run with:
+    pytest backend/tests/test_ml_fallback.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_role_bundle(confidence: float, role_labels: list[str] | None = None) -> dict:
+    """
+    Build a minimal ml_bundle that makes predict_role return *confidence*
+    for the first label.
+    """
+    labels = role_labels or ["Data Scientist", "Backend Developer", "ML Engineer"]
+    n = len(labels)
+
+    model = MagicMock()
+    model.predict.return_value = [0]                          # always pick index 0
+
+    proba = np.zeros(n, dtype=np.float32)
+    proba[0] = confidence
+    # Distribute the remaining probability mass uniformly
+    if n > 1:
+        rest = (1.0 - confidence) / (n - 1)
+        proba[1:] = rest
+    model.predict_proba.return_value = [proba]
+
+    return {
+        "role_predictor": model,
+        "role_config": {
+            "feature_names": ["python", "sql", "docker"],
+            "role_labels":   labels,
+        },
+    }
+
+
+def _make_lstm_bundle(raise_on_predict: bool = False) -> dict:
+    """
+    Build a minimal ml_bundle for the LSTM path.
+    If *raise_on_predict* is True the model.predict() call will raise RuntimeError.
+    """
+    lstm = MagicMock()
+    if raise_on_predict:
+        lstm.predict.side_effect = RuntimeError("CUDA out of memory")
+    else:
+        # Return all-zero probabilities (nothing recommended)
+        lstm.predict.return_value = [np.zeros(3, dtype=np.float32)]
+
+    mlb = MagicMock()
+    mlb.classes_ = np.array(["TensorFlow", "Docker", "Kubernetes"])
+
+    role_enc = MagicMock()
+    role_enc.transform.return_value = np.zeros((1, 5), dtype=np.float32)
+
+    sen_enc = MagicMock()
+    sen_enc.transform.return_value = np.zeros((1, 4), dtype=np.float32)
+
+    return {
+        "lstm_model":        lstm,
+        "lstm_mlb":          mlb,
+        "role_encoder":      role_enc,
+        "seniority_encoder": sen_enc,
+    }
+
+
+# ── Patch sentence-transformers so LSTM tests don't download models ────────────
+
+def _patch_sentence_transformers():
+    """Return a context-manager that stubs out SentenceTransformer."""
+    st_mod   = types.ModuleType("sentence_transformers")
+    st_class = MagicMock()
+    # encode() returns a zero vector of the right shape
+    st_class.return_value.encode.return_value = np.zeros(384, dtype=np.float32)
+    st_mod.SentenceTransformer = st_class
+    return patch.dict(sys.modules, {"sentence_transformers": st_mod})
+
+
+# =============================================================================
+# 1. Role-predictor: confidence below threshold
+# =============================================================================
+
+class TestRoleConfidenceFallback:
+    """
+    When the Random Forest's top-class probability < ROLE_CONFIDENCE_THRESHOLD (0.60)
+    predict_role() must return source="low_confidence" instead of "ml".
+    """
+
+    def _call(self, confidence: float) -> dict:
+        import importlib
+        import ml_inference
+        importlib.reload(ml_inference)
+
+        bundle = _make_role_bundle(confidence)
+        return ml_inference.predict_role(["python", "sql"], bundle)
+
+    def test_below_threshold_returns_low_confidence_source(self):
+        result = self._call(0.45)
+        assert result["source"] == "low_confidence", (
+            f"Expected source='low_confidence', got {result['source']!r}"
+        )
+
+    def test_below_threshold_preserves_predicted_role_for_logging(self):
+        """The role name must be preserved so the caller can log what was discarded."""
+        result = self._call(0.45)
+        assert result["predicted_role"] == "Data Scientist"
+
+    def test_below_threshold_preserves_actual_confidence_value(self):
+        result = self._call(0.45)
+        assert abs(result["confidence"] - 0.45) < 0.01
+
+    def test_above_threshold_returns_ml_source(self):
+        result = self._call(0.85)
+        assert result["source"] == "ml"
+
+    def test_exactly_at_threshold_returns_ml_source(self):
+        """Boundary: 0.60 is inclusive (≥ threshold passes)."""
+        result = self._call(0.60)
+        assert result["source"] == "ml"
+
+    def test_just_below_threshold_returns_low_confidence(self):
+        result = self._call(0.599)
+        assert result["source"] == "low_confidence"
+
+
+# =============================================================================
+# 2. Model file missing — bundle is None or all artifacts are None
+# =============================================================================
+
+class TestModelFileMissing:
+    """
+    When the ML bundle is None (startup failed to find model files) both
+    predict_role() and predict_missing_skills() must return source="fallback"
+    without raising any exception.
+    """
+
+    def test_predict_role_none_bundle_returns_fallback(self):
+        import importlib
+        import ml_inference
+        importlib.reload(ml_inference)
+
+        result = ml_inference.predict_role(["python"], {})
+        assert result["source"] == "fallback"
+        assert result["predicted_role"] is None
+        assert result["confidence"] == 0.0
+        assert result["top_roles"] == []
+
+    def test_predict_role_none_model_inside_bundle_returns_fallback(self):
+        import importlib
+        import ml_inference
+        importlib.reload(ml_inference)
+
+        # Bundle present but model artifact is None (FileNotFoundError at load time)
+        bundle = {"role_predictor": None, "role_config": {"feature_names": [], "role_labels": []}}
+        result = ml_inference.predict_role(["python"], bundle)
+        assert result["source"] == "fallback"
+
+    def test_predict_missing_skills_none_bundle_returns_fallback(self):
+        import importlib
+        import ml_inference
+        importlib.reload(ml_inference)
+
+        result = ml_inference.predict_missing_skills(
+            current_skills=["python"],
+            target_role="Data Scientist",
+            bundle=None,
+        )
+        assert result["source"] == "fallback"
+        assert result["missing_skills"] == []
+        assert result["confidences"] == {}
+
+    def test_predict_missing_skills_missing_lstm_artifact_returns_fallback(self):
+        import importlib
+        import ml_inference
+        importlib.reload(ml_inference)
+
+        # Partial bundle – lstm_model present but role_encoder is None
+        bundle = {
+            "lstm_model":        MagicMock(),
+            "lstm_mlb":          MagicMock(),
+            "role_encoder":      None,      # ← missing artifact
+            "seniority_encoder": MagicMock(),
+        }
+        result = ml_inference.predict_missing_skills(
+            current_skills=["python"],
+            target_role="Data Scientist",
+            bundle=bundle,
+        )
+        assert result["source"] == "fallback"
+
+    def test_no_exception_raised_when_bundle_is_none(self):
+        """Pipeline must never raise; fallback dicts are always returned."""
+        import importlib
+        import ml_inference
+        importlib.reload(ml_inference)
+
+        try:
+            ml_inference.predict_role([], {})
+            ml_inference.predict_missing_skills([], "Unknown Role", bundle=None)
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"Unexpected exception raised: {exc}")
+
+
+# =============================================================================
+# 3. LSTM inference exception
+# =============================================================================
+
+class TestLSTMInferenceFallback:
+    """
+    When the LSTM model.predict() raises (e.g. shape mismatch, OOM)
+    predict_missing_skills() must catch it and return source="fallback"
+    with empty lists — never propagating the exception.
+    """
+
+    def _call(self, raise_on_predict: bool = True) -> dict:
+        import importlib
+        import ml_inference
+        importlib.reload(ml_inference)
+
+        bundle = _make_lstm_bundle(raise_on_predict=raise_on_predict)
+
+        with _patch_sentence_transformers():
+            return ml_inference.predict_missing_skills(
+                current_skills=["python", "sql"],
+                target_role="Data Scientist",
+                seniority="Mid-level",
+                bundle=bundle,
+                top_n=5,
+            )
+
+    def test_lstm_exception_returns_fallback_source(self):
+        result = self._call(raise_on_predict=True)
+        assert result["source"] == "fallback"
+
+    def test_lstm_exception_returns_empty_missing_skills(self):
+        result = self._call(raise_on_predict=True)
+        assert result["missing_skills"] == []
+
+    def test_lstm_exception_returns_empty_confidences(self):
+        result = self._call(raise_on_predict=True)
+        assert result["confidences"] == {}
+
+    def test_lstm_exception_does_not_propagate(self):
+        """The exception must be swallowed and logged, not re-raised."""
+        try:
+            self._call(raise_on_predict=True)
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"Exception propagated to caller: {exc}")
+
+    def test_lstm_no_exception_returns_ml_source(self):
+        """Sanity check: a clean inference returns source='ml'."""
+        import importlib
+        import ml_inference
+        importlib.reload(ml_inference)
+
+        bundle = _make_lstm_bundle(raise_on_predict=False)
+        # Patch mlb.classes_ and return a non-trivial prediction
+        classes = np.array(["TensorFlow", "Docker", "Kubernetes"])
+        bundle["lstm_mlb"].classes_ = classes
+        # Make predictions: all skills already owned → recommended list empty
+        bundle["lstm_model"].predict.return_value = [
+            np.array([0.9, 0.8, 0.7], dtype=np.float32)
+        ]
+
+        with _patch_sentence_transformers():
+            result = ml_inference.predict_missing_skills(
+                current_skills=[],          # user has nothing → all recommended
+                target_role="Data Scientist",
+                bundle=bundle,
+                top_n=3,
+            )
+        assert result["source"] == "ml"
+        assert len(result["missing_skills"]) > 0
+
+
+# =============================================================================
+# 4. _static_skill_gap helper (worker.py)
+# =============================================================================
+
+class TestStaticSkillGap:
+    """
+    Unit tests for the _static_skill_gap() helper extracted in worker.py.
+    Ensures it correctly subtracts found skills from the required set.
+    """
+
+    def _get_fn(self):
+        import importlib
+        import worker
+        importlib.reload(worker)
+        return worker._static_skill_gap
+
+    def test_known_role_returns_missing_skills(self):
+        fn = self._get_fn()
+        result = fn("Backend Developer", ["Python", "Docker"])
+        # Node.js, SQL, AWS, API Design, MongoDB, FastAPI should be missing
+        assert "Node.js" in result
+        assert "Python" not in result
+        assert "Docker" not in result
+
+    def test_case_insensitive_matching(self):
+        fn = self._get_fn()
+        result = fn("Data Scientist", ["python", "SQL"])   # lowercase input
+        assert "Python" not in result
+        assert "SQL" not in result
+
+    def test_unknown_role_returns_empty_list(self):
+        fn = self._get_fn()
+        result = fn("Quantum Engineer", ["python"])
+        assert result == []
+
+    def test_empty_found_skills_returns_all_required(self):
+        fn = self._get_fn()
+        result = fn("Frontend Developer", [])
+        assert len(result) > 0
+
+    def test_all_skills_present_returns_empty(self):
+        fn = self._get_fn()
+        all_fe = ["React", "JavaScript", "HTML", "CSS", "TypeScript", "TailwindCSS", "Next.js"]
+        result = fn("Frontend Developer", all_fe)
+        assert result == []

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -64,6 +64,19 @@ _DEFAULT_ROLES_DB = {
 }
 
 
+def _static_skill_gap(role: str, found_skills: list[str]) -> list[str]:
+    """
+    Rule-based fallback: return skills required for *role* that the candidate
+    does not already have.
+
+    Uses the built-in _DEFAULT_ROLES_DB table.  Unknown roles return an empty
+    list rather than raising so the pipeline always completes.
+    """
+    required = _DEFAULT_ROLES_DB.get(role, [])
+    found_lower = {s.lower() for s in found_skills}
+    return [s for s in required if s.lower() not in found_lower]
+
+
 # ── Main worker ───────────────────────────────────────────────────────────────
 
 async def run_analysis(
@@ -106,21 +119,37 @@ async def run_analysis(
             {"predicted_role": None, "confidence": 0.0, "top_roles": [], "source": "fallback"}
 
         if ml_role_result["source"] == "ml" and role == "Auto Detect":
-            target_role     = ml_role_result["predicted_role"]
+            # High-confidence ML prediction – use it directly
+            target_role       = ml_role_result["predicted_role"]
             identified_skills = found_skills
             logger.info("[job=%s] ML role=%s (%.0f%%)", job_id, target_role, ml_role_result["confidence"] * 100)
         else:
-            # NLP fallback
+            # Covers: source=="fallback" (model missing), "low_confidence", or user-selected role
+            if ml_role_result["source"] == "low_confidence":
+                logger.warning(
+                    "[job=%s] Role confidence %.4f below threshold – "
+                    "discarding ML prediction '%s', running NLP fallback",
+                    job_id,
+                    ml_role_result["confidence"],
+                    ml_role_result["predicted_role"],
+                )
+
             from database import jobs_collection  # noqa: PLC0415
             cursor   = jobs_collection.find({})
             db_roles = await cursor.to_list(length=100)
             roles_db = {r["role_name"]: r["required_skills"] for r in db_roles} or _DEFAULT_ROLES_DB
-            analysis         = match_role_and_skills(found_skills, roles_db, role)
-            target_role      = analysis["target_role"]
+            analysis          = match_role_and_skills(found_skills, roles_db, role)
+            target_role       = analysis["target_role"]
             identified_skills = analysis["identified_skills"]
-            logger.info("[job=%s] NLP role=%s", job_id, target_role)
 
-        # ── 4. Missing-skills (LSTM → rule-based fallback) ────────────
+            # When ML returned low-confidence override to "Auto Detect" so the
+            # frontend knows the role was not reliably determined.
+            if ml_role_result["source"] == "low_confidence":
+                target_role = "Auto Detect"
+
+            logger.info("[job=%s] NLP role=%s (ml_source=%s)", job_id, target_role, ml_role_result["source"])
+
+        # ── 4. Missing-skills (LSTM → static lookup fallback) ────────────────
         seniority  = "Mid-level"
         ml_missing = predict_missing_skills(
             current_skills=found_skills,
@@ -131,20 +160,31 @@ async def run_analysis(
         )
 
         if ml_missing["source"] == "ml" and ml_missing["missing_skills"]:
+            # LSTM succeeded with results – use them
             missing_skills    = ml_missing["missing_skills"]
             identified_skills = found_skills
             logger.info("[job=%s] LSTM predicted %d missing skills", job_id, len(missing_skills))
         else:
-            # Rule-based fallback — re-query if we used ML for role
-            if ml_role_result["source"] == "ml":
-                from database import jobs_collection  # noqa: PLC0415
-                cursor   = jobs_collection.find({})
-                db_roles = await cursor.to_list(length=100)
-                roles_db = {r["role_name"]: r["required_skills"] for r in db_roles} or _DEFAULT_ROLES_DB
-                analysis = match_role_and_skills(found_skills, roles_db, target_role or "Auto Detect")
-            missing_skills    = analysis["missing_skills"]
-            identified_skills = analysis["identified_skills"]
-            logger.info("[job=%s] NLP fallback: %d missing skills", job_id, len(missing_skills))
+            # LSTM unavailable, raised an exception, or returned nothing –
+            # use the static skill-gap lookup table as the authoritative fallback.
+            logger.warning(
+                "[job=%s] LSTM fallback (source=%s): using static skill-gap table for role '%s'",
+                job_id, ml_missing["source"], target_role,
+            )
+            missing_skills = _static_skill_gap(target_role or "", found_skills)
+            # Re-run NLP gap analysis when the static table has no entry for this role
+            if not missing_skills:
+                if ml_role_result["source"] == "ml":
+                    from database import jobs_collection  # noqa: PLC0415
+                    cursor   = jobs_collection.find({})
+                    db_roles = await cursor.to_list(length=100)
+                    roles_db = {r["role_name"]: r["required_skills"] for r in db_roles} or _DEFAULT_ROLES_DB
+                    analysis = match_role_and_skills(found_skills, roles_db, target_role or "Auto Detect")
+                missing_skills    = analysis.get("missing_skills", [])
+                identified_skills = analysis.get("identified_skills", found_skills)
+            # Tag this result so consumers know the source
+            ml_missing = {**ml_missing, "source": "static_lookup"}
+            logger.info("[job=%s] static_lookup: %d missing skills", job_id, len(missing_skills))
 
         # ── 5. Readiness score ────────────────────────────────────────
         readiness_score = compute_readiness_score(identified_skills, missing_skills)


### PR DESCRIPTION
## Description
This PR implements robust fallback mechanisms across the ML pipeline to ensure the application remains functional even when ML models are unavailable, fail during inference, or produce low-confidence results. It replaces potential 500 errors with deterministic, rule-based fallbacks.

## Key Changes

### 1. Confidence-Based Fallback
- Added a `0.60` threshold for the Role Predictor. 
- Predictions below this threshold are tagged as `low_confidence` and the system automatically falls back to NLP role matching to ensure accuracy.

### 2. LSTM & Missing Model Logic
- **Static Lookup Table**: Extracted a dedicated `_static_skill_gap` helper that acts as the authoritative fallback when the LSTM model cannot be reached or returns an empty set.
- **Graceful Degradation**: If model files are missing at startup (e.g., incorrect versioning), the system now labels the source as `fallback` and continues without crashing.

### 3. Observability & Provenance
- **Contextual Logging**: All fallback events now log the specific Job ID and the reason for failure (e.g., "Confidence 0.45 < threshold").
- **Enhanced Metadata**: Updated the API schema to include `low_confidence` and `static_lookup` in the provenance fields (`ml_role_source` / `ml_missing_source`).

### 4. Testing
- Created `tests/test_ml_fallback.py` containing **21 unit tests**. These tests use mocks to verify fallback behavior for:
  - Low confidence scores.
  - Missing model artifacts.
  - Runtime exceptions during inference.
  - Case-insensitive static skill lookups.

## Verification
To verify the logic, run the newly added test suite:
```bash
pytest backend/tests/test_ml_fallback.py -v
```

## Acceptance Criteria
- [x] Fallback logic tested for all 3 models.
- [x] Error responses follow standard error schema.
- [x] No 500 errors surfaced to client for known failure modes.