### PR TITLE
feat(nlp): update roadmap generation to use LSTM-ranked missing skills

### DIFF
--- a/backend/nlp/engine.py
+++ b/backend/nlp/engine.py
@@ -151,19 +151,39 @@ def match_role_and_skills(resume_skills, roles_db, user_given_role=None):
         "identified_skills": list(resume_skills_set)
     }
 
-def generate_roadmap(missing_skills):
+import urllib.parse
+
+def generate_roadmap(missing_skills_ranked):
+    if not missing_skills_ranked:
+        return []
+
+    # Handle legacy lists of strings gracefully
+    normalized = []
+    for item in missing_skills_ranked:
+        if isinstance(item, str):
+            normalized.append({"skill": item, "likelihood": 0.5, "priority": "medium"})
+        else:
+            normalized.append(item)
+
+    # Sort by likelihood (highest first) so high-likelihood skills appear in first weeks
+    sorted_skills = sorted(normalized, key=lambda x: x.get("likelihood", 0.0), reverse=True)
+
     roadmap = []
     week = 1
-    for skill in missing_skills:
+    for item in sorted_skills:
+        skill = item["skill"]
+        encoded = urllib.parse.quote(skill)
+        
         roadmap.append({
             "week": f"Week {week}-{week+1}",
             "focus": f"{skill.title()} Basics & Application",
             "resources": [
-                f"Coursera: Modern {skill.title()}",
-                f"YouTube: {skill.title()} Crash Course"
+                f"Coursera: https://www.coursera.org/search?query={encoded}",
+                f"YouTube: https://www.youtube.com/results?search_query={encoded}+crash+course"
             ]
         })
         week += 2
+        
     return roadmap
 
 def generate_interview_questions(missing_skills):

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -217,7 +217,7 @@ async def run_analysis(
         missing_skills_ranked = rank_missing_skills(missing_skills, missing_confidences)
 
         # ── 7. Roadmap + interview questions ──────────────────────────
-        roadmap      = generate_roadmap(missing_skills)
+        roadmap      = generate_roadmap(missing_skills_ranked)
         interview_qs = generate_interview_questions(missing_skills)
 
         # ── 8. Persist full result to analyses_collection ─────────────


### PR DESCRIPTION
## Description
This PR upgrades the roadmap generation logic to utilize the LSTM-derived `missing_skills_ranked` metadata. Instead of a generic list, the roadmap is now a prioritized learning plan that schedules the most critical skills first based on their likelihood scores.

## Key Changes

### 1. Likelihood-Based Prioritization
- Updated `generate_roadmap` in `nlp/engine.py` to sort missing skills by their `likelihood` score in descending order.
- This ensures "High Priority" skills (likelihood > 0.75) consistently appear in the first weeks of the learning plan.

### 2. Dynamic Course Resources
- Replaced static strings with dynamic, clickable search links.
- Uses `urllib.parse` to generate search queries for **Coursera** and **YouTube** tailored to each specific skill (e.g., `...search?query=FastAPI+crash+course`).

### 3. Pipeline Integration
- Updated `worker.py` to pass the `missing_skills_ranked` list to the roadmap generator.
- Implemented a normalization layer in the generator to gracefully handle fallbacks to plain strings if ML features are unavailable.

## Acceptance Criteria
- [x] High-likelihood skills appear in first 2 weeks.
- [x] Course resource links populated per skill (clickable search URLs).
- [x] Roadmap serialized correctly in the final analysis JSON response.

## Verification
You can verify the sorting and link generation logic with this snippet:
```python
from nlp.engine import generate_roadmap
mock_ranked = [
    {'skill': 'docker', 'likelihood': 0.45},
    {'skill': 'python', 'likelihood': 0.95} # Python will appear first
]
print(generate_roadmap(mock_ranked))
```