### PR TITLE
feat(ml): wire RF role predictor with interpretability and sync endpoint

### DIFF
--- a/backend/ml_inference.py
+++ b/backend/ml_inference.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +59,39 @@ def _skills_to_vector(skills: list[str], feature_names: list[str]) -> np.ndarray
 
 # ── Public API ────────────────────────────────────────────────────────────────
 
+# Number of top predictive skills to surface in the response.
+_TOP_PREDICTIVE_SKILLS_N: int = 5
+
+
+def _top_predictive_skills(
+    vec: "np.ndarray",
+    feat_names: list[str],
+    model,
+    top_n: int = _TOP_PREDICTIVE_SKILLS_N,
+) -> list[str]:
+    """
+    Return the names of the user's skills that contributed most to the
+    Random Forest prediction, ranked by ``feature_importances_``.
+
+    Only features where the user has the skill (vec[i] == 1) are considered.
+    Returns an empty list if the model has no ``feature_importances_`` attribute.
+    """
+    importances = getattr(model, "feature_importances_", None)
+    if importances is None or len(importances) != len(feat_names):
+        return []
+
+    # Mask to only the skills the user actually has
+    user_mask   = vec.astype(bool)
+    scores      = importances * user_mask          # zero out skills not in resume
+    top_indices = np.argsort(scores)[::-1][:top_n]
+
+    return [
+        feat_names[i]
+        for i in top_indices
+        if user_mask[i]  # double-check — guard against floating-point edge cases
+    ]
+
+
 def predict_role(
     skills: list[str],
     bundle: dict,
@@ -69,34 +103,68 @@ def predict_role(
     Returns
     -------
     {
-        "predicted_role": str,
-        "confidence": float (0-1),
-        "top_roles": [{"role": str, "confidence": float}, ...],
-        "source": "ml" | "fallback"
+        "predicted_role":        str,
+        "confidence":            float  (0-1),
+        "top_roles":             [{"role": str, "confidence": float}, ...],
+        "role_probabilities":    {role: float, ...},          # full dict
+        "top_predictive_skills": [str, ...],                  # from feature_importances_
+        "inference_ms":          float,                       # wall-clock ms
+        "source":                "ml" | "low_confidence" | "fallback"
     }
     """
     model       = bundle.get("role_predictor")
     feat_names  = _feature_names(bundle)
     role_labels = _role_labels(bundle)
 
+    _EMPTY = {
+        "predicted_role":        None,
+        "confidence":            0.0,
+        "top_roles":             [],
+        "role_probabilities":    {},
+        "top_predictive_skills": [],
+        "inference_ms":          0.0,
+        "source":                "fallback",
+    }
+
     if model is None or not feat_names or not role_labels:
         logger.warning("role_predictor not available – returning source=fallback")
-        return {"predicted_role": None, "confidence": 0.0, "top_roles": [], "source": "fallback"}
+        return _EMPTY
 
     try:
-        vec         = _skills_to_vector(skills, feat_names)
-        pred_idx    = int(model.predict([vec])[0])
-        proba       = model.predict_proba([vec])[0]
+        t0  = time.perf_counter()
 
+        vec      = _skills_to_vector(skills, feat_names)
+        pred_idx = int(model.predict([vec])[0])
+        proba    = model.predict_proba([vec])[0]
+
+        inference_ms = round((time.perf_counter() - t0) * 1000, 2)
+        if inference_ms > 50:
+            logger.warning(
+                "predict_role: inference took %.2f ms (> 50 ms SLA) for %d skills",
+                inference_ms, len(skills),
+            )
+        else:
+            logger.debug("predict_role: inference %.2f ms", inference_ms)
+
+        # ── Top-N role list (backward compat) ────────────────────────
         top_indices = np.argsort(proba)[::-1][:top_n]
         top_roles   = [
             {"role": role_labels[i], "confidence": round(float(proba[i]), 4)}
             for i in top_indices
         ]
 
+        # ── Full probability map {role: prob} ─────────────────────────
+        role_probabilities = {
+            role_labels[i]: round(float(proba[i]), 4)
+            for i in range(len(role_labels))
+        }
+
+        # ── Top skills that drove the prediction ──────────────────────
+        top_pred_skills = _top_predictive_skills(vec, feat_names, model)
+
         confidence = round(float(proba[pred_idx]), 4)
 
-        # ── Confidence threshold gate ────────────────────────────────
+        # ── Confidence threshold gate ─────────────────────────────────
         if confidence < ROLE_CONFIDENCE_THRESHOLD:
             logger.warning(
                 "predict_role: confidence %.4f < threshold %.2f for role '%s' – "
@@ -104,25 +172,40 @@ def predict_role(
                 confidence, ROLE_CONFIDENCE_THRESHOLD, role_labels[pred_idx],
             )
             return {
-                "predicted_role": role_labels[pred_idx],   # kept for logging
-                "confidence":     confidence,
-                "top_roles":      top_roles,
-                "source":         "low_confidence",
+                "predicted_role":        role_labels[pred_idx],  # kept for logging
+                "confidence":            confidence,
+                "top_roles":             top_roles,
+                "role_probabilities":    role_probabilities,
+                "top_predictive_skills": top_pred_skills,
+                "inference_ms":          inference_ms,
+                "source":                "low_confidence",
             }
 
         return {
-            "predicted_role": role_labels[pred_idx],
-            "confidence":     confidence,
-            "top_roles":      top_roles,
-            "source":         "ml",
+            "predicted_role":        role_labels[pred_idx],
+            "confidence":            confidence,
+            "top_roles":             top_roles,
+            "role_probabilities":    role_probabilities,
+            "top_predictive_skills": top_pred_skills,
+            "inference_ms":          inference_ms,
+            "source":                "ml",
         }
+
     except Exception as exc:
         logger.error(
             "predict_role error (%s): %s",
             type(exc).__name__, exc,
             exc_info=True,
         )
-        return {"predicted_role": None, "confidence": 0.0, "top_roles": [], "source": "fallback"}
+        return {
+            "predicted_role":        None,
+            "confidence":            0.0,
+            "top_roles":             [],
+            "role_probabilities":    {},
+            "top_predictive_skills": [],
+            "inference_ms":          0.0,
+            "source":                "fallback",
+        }
 
 
 def predict_missing_skills(

--- a/backend/models.py
+++ b/backend/models.py
@@ -196,6 +196,10 @@ class AnalysisResult(BaseModel):
                                                            description="Confidence for the predicted role")
     role_alternatives:     List[RoleAlternative]   = Field(default_factory=list,
                                                            description="Top alternative role predictions")
+    role_probabilities:    dict                    = Field(default_factory=dict,
+                                                           description="Full {role: probability} map for all roles")
+    top_predictive_skills: List[str]               = Field(default_factory=list,
+                                                           description="User's skills most predictive for the predicted role")
     skill_categories:      dict                    = Field(default_factory=dict,
                                                            description="Detected skills grouped by domain")
     missing_skills_ranked: List[MissingSkillRanked] = Field(default_factory=list,
@@ -244,6 +248,13 @@ class AnalysisResult(BaseModel):
                     {"role": "ML Engineer", "confidence": 0.06},
                     {"role": "Data Analyst",  "confidence": 0.02},
                 ],
+                "role_probabilities": {
+                    "Data Scientist": 0.92,
+                    "ML Engineer": 0.06,
+                    "Backend Developer": 0.01,
+                    "Frontend Developer": 0.01,
+                },
+                "top_predictive_skills": ["Python", "scikit-learn", "Pandas"],
                 "skill_categories": {
                     "data":     ["Python", "Pandas", "SQL"],
                     "general":  [],
@@ -277,3 +288,57 @@ class JobStatusResponse(BaseModel):
     result:     Optional[AnalysisResult] = None   # present when status=completed
     error:      Optional[str]   = None            # present when status=failed
 
+
+# ── /predict-role endpoint models ────────────────────────────────────────────
+
+class PredictRoleRequest(BaseModel):
+    """Request body for POST /api/v1/predict-role."""
+    skills: List[str] = Field(
+        ...,
+        min_length=1,
+        description="List of skills extracted from a resume or entered manually.",
+        json_schema_extra={"example": ["Python", "Pandas", "scikit-learn", "SQL", "TensorFlow"]},
+    )
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {"skills": ["Python", "Pandas", "scikit-learn", "SQL", "TensorFlow"]}
+        }
+    )
+
+
+class PredictRoleResponse(BaseModel):
+    """
+    Response for the synchronous POST /api/v1/predict-role endpoint.
+
+    Provides the Random Forest role prediction together with interpretability
+    fields so the frontend can display *why* a role was chosen.
+    """
+    predicted_role:        str              = Field(description="Best-matching role or 'Auto Detect' when confidence is low")
+    confidence:            float            = Field(ge=0.0, le=1.0, description="Model confidence (0–1)")
+    role_probabilities:    dict             = Field(description="Full {role: probability} map")
+    top_predictive_skills: List[str]        = Field(description="User skills most predictive for the result")
+    role_alternatives:     List[RoleAlternative] = Field(default_factory=list,
+                                                         description="Next-best role predictions")
+    inference_ms:          float            = Field(default=0.0, description="Server-side inference time in ms")
+    source:                str              = Field(description="'ml' | 'low_confidence' | 'fallback'")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "predicted_role": "Data Scientist",
+                "confidence": 0.87,
+                "role_probabilities": {
+                    "Data Scientist": 0.87,
+                    "ML Engineer": 0.09,
+                    "Backend Developer": 0.04,
+                },
+                "top_predictive_skills": ["Python", "scikit-learn", "Pandas"],
+                "role_alternatives": [
+                    {"role": "ML Engineer", "confidence": 0.09},
+                ],
+                "inference_ms": 3.7,
+                "source": "ml",
+            }
+        }
+    )

--- a/backend/routes/jobs.py
+++ b/backend/routes/jobs.py
@@ -27,7 +27,13 @@ from fastapi import (
 )
 
 from database import analysis_jobs_collection, jobs_collection
-from models import AnalysisResult, JobAcceptedResponse, JobStatusResponse
+from models import (
+    AnalysisResult,
+    JobAcceptedResponse,
+    JobStatusResponse,
+    PredictRoleRequest,
+    PredictRoleResponse,
+)
 from security import get_current_user
 from worker import run_analysis
 
@@ -201,6 +207,8 @@ async def get_job_status(
             # ML enrichment
             "role_confidence":        raw.get("role_confidence", 0.0),
             "role_alternatives":      raw.get("role_alternatives", []),
+            "role_probabilities":     raw.get("role_probabilities", {}),
+            "top_predictive_skills":  raw.get("top_predictive_skills", []),
             "skill_categories":       raw.get("skill_categories", {}),
             "missing_skills_ranked":  raw.get("missing_skills_ranked", []),
             "model_version":          raw.get("model_version", "unknown"),
@@ -217,4 +225,72 @@ async def get_job_status(
         updated_at=job.get("updated_at"),
         result=result,
         error=job.get("error"),
+    )
+
+
+# ── POST /predict-role ─────────────────────────────────────────────────────────
+
+@router.post(
+    "/predict-role",
+    response_model=PredictRoleResponse,
+    summary="Predict role from a skills list",
+    description=(
+        "Runs the trained Random Forest role predictor synchronously on a list of "
+        "skills and returns the predicted role, full probability map, the top skills "
+        "that drove the prediction, and the server-side inference time. "
+        "Responds immediately (no background task). Requires JWT authentication."
+    ),
+    tags=["Resume Analysis"],
+)
+async def predict_role_endpoint(
+    request:      Request,
+    body:         PredictRoleRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Synchronous role prediction endpoint.
+
+    Uses the Random Forest model loaded at startup.  When confidence is below
+    the 0.60 threshold, ``predicted_role`` is set to ``"Auto Detect"`` and
+    ``source`` is ``"low_confidence"``.
+    """
+    from ml_inference import predict_role as _predict_role  # noqa: PLC0415
+
+    ml_bundle = getattr(request.app.state, "ml_models", None)
+    if ml_bundle is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="ML models are not loaded. Try again in a few seconds.",
+        )
+
+    result = _predict_role(skills=body.skills, bundle=ml_bundle)
+
+    # Apply the same confidence-fallback logic as the worker pipeline
+    predicted_role = result["predicted_role"]
+    if result["source"] == "low_confidence":
+        predicted_role = "Auto Detect"
+
+    role_alternatives = [
+        {"role": r["role"], "confidence": r["confidence"]}
+        for r in result.get("top_roles", [])
+        if r["role"] != predicted_role
+    ]
+
+    logger.info(
+        "predict-role: user=%s  role=%s  confidence=%.4f  source=%s  ms=%.2f",
+        current_user["id"],
+        predicted_role,
+        result["confidence"],
+        result["source"],
+        result.get("inference_ms", 0.0),
+    )
+
+    return PredictRoleResponse(
+        predicted_role=predicted_role or "Auto Detect",
+        confidence=result["confidence"],
+        role_probabilities=result.get("role_probabilities", {}),
+        top_predictive_skills=result.get("top_predictive_skills", []),
+        role_alternatives=role_alternatives,
+        inference_ms=result.get("inference_ms", 0.0),
+        source=result["source"],
     )

--- a/backend/tests/test_role_predictor_inference.py
+++ b/backend/tests/test_role_predictor_inference.py
@@ -1,0 +1,490 @@
+"""
+tests/test_role_predictor_inference.py
+=======================================
+Unit tests for the enhanced predict_role() in ml_inference.py and the
+new POST /api/v1/predict-role FastAPI endpoint.
+
+Covers:
+  1. top_predictive_skills — derived from feature_importances_
+  2. role_probabilities    — full {role: prob} dict
+  3. inference_ms          — timing field present in all return paths
+  4. Output schema          — all new keys present regardless of source
+  5. <50 ms SLA            — warning is triggered when mock is slow
+  6. /predict-role endpoint — smoke tests via FastAPI TestClient
+
+No real model files or MongoDB connections required — all heavy objects
+are mocked.
+
+Run with:
+    pytest backend/tests/test_role_predictor_inference.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+# ── Shared constants ──────────────────────────────────────────────────────────
+
+_ROLE_LABELS   = ["Data Scientist", "Backend Developer", "Frontend Developer"]
+_FEAT_NAMES    = ["python", "sql", "react", "docker", "pandas", "scikit-learn"]
+_N_FEATS       = len(_FEAT_NAMES)
+_N_ROLES       = len(_ROLE_LABELS)
+
+
+# ── Bundle builders ───────────────────────────────────────────────────────────
+
+def _make_bundle(
+    confidence: float = 0.85,
+    pred_idx:   int   = 0,
+    with_importances: bool = True,
+) -> dict:
+    """
+    Build a minimal ml_bundle whose role_predictor behaves deterministically.
+
+    Parameters
+    ----------
+    confidence       : probability assigned to pred_idx
+    pred_idx         : index into _ROLE_LABELS to predict
+    with_importances : whether model has feature_importances_ attribute
+    """
+    model = MagicMock()
+    model.predict.return_value = [pred_idx]
+
+    proba = np.zeros(_N_ROLES, dtype=np.float32)
+    proba[pred_idx] = confidence
+    remaining = (1.0 - confidence) / max(_N_ROLES - 1, 1)
+    for i in range(_N_ROLES):
+        if i != pred_idx:
+            proba[i] = remaining
+    model.predict_proba.return_value = [proba]
+
+    if with_importances:
+        # Give importance to python (idx 0) and pandas (idx 4)
+        importances = np.zeros(_N_FEATS, dtype=np.float32)
+        importances[0] = 0.40   # python
+        importances[4] = 0.30   # pandas
+        importances[5] = 0.20   # scikit-learn
+        importances[1] = 0.10   # sql
+        model.feature_importances_ = importances
+    else:
+        # Simulate a model that has no importances (e.g. SVM)
+        del model.feature_importances_
+
+    return {
+        "role_predictor": model,
+        "role_config": {
+            "feature_names": _FEAT_NAMES,
+            "role_labels":   _ROLE_LABELS,
+        },
+    }
+
+
+def _reload() -> object:
+    import ml_inference
+    importlib.reload(ml_inference)
+    return ml_inference
+
+
+# =============================================================================
+# 1. top_predictive_skills
+# =============================================================================
+
+class TestTopPredictiveSkills:
+    """
+    top_predictive_skills must:
+      - be derived from feature_importances_ × user skill binary vector
+      - only include skills the user actually has (vec[i] == 1)
+      - be sorted descending by feature importance
+      - be empty when the model has no feature_importances_
+    """
+
+    def test_returns_list_of_strings(self):
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85, with_importances=True)
+        result = mi.predict_role(["python", "pandas"], bundle)
+        assert isinstance(result["top_predictive_skills"], list)
+        assert all(isinstance(s, str) for s in result["top_predictive_skills"])
+
+    def test_only_contains_user_skills(self):
+        """Must not contain skills the user does NOT have."""
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85, with_importances=True)
+        # User has python + sql only
+        result = mi.predict_role(["python", "sql"], bundle)
+        user_skills_lower = {"python", "sql"}
+        for skill in result["top_predictive_skills"]:
+            assert skill.lower() in user_skills_lower, (
+                f"'{skill}' not in user skills — should not appear"
+            )
+
+    def test_sorted_by_importance_descending(self):
+        """Skills with higher feature_importances_ must come first."""
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85, with_importances=True)
+        # User has python (importance 0.40) and pandas (importance 0.30)
+        result = mi.predict_role(["python", "pandas", "scikit-learn"], bundle)
+        top = result["top_predictive_skills"]
+        # python has highest importance — must be first if present
+        assert len(top) > 0
+        assert top[0].lower() == "python"
+
+    def test_empty_when_no_feature_importances(self):
+        """If the model has no feature_importances_, return []."""
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85, with_importances=False)
+        result = mi.predict_role(["python", "pandas"], bundle)
+        assert result["top_predictive_skills"] == []
+
+    def test_empty_skills_input_returns_empty_list(self):
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85, with_importances=True)
+        result = mi.predict_role([], bundle)
+        assert result["top_predictive_skills"] == []
+
+    def test_capped_at_top_5_by_default(self):
+        """At most 5 skills should be returned (the default _TOP_PREDICTIVE_SKILLS_N)."""
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85, with_importances=True)
+        # Give the user all features
+        result = mi.predict_role(list(_FEAT_NAMES), bundle)
+        assert len(result["top_predictive_skills"]) <= 5
+
+    def test_unknown_skills_not_in_result(self):
+        """Skills not in the feature vocabulary should not appear (they map to 0)."""
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85, with_importances=True)
+        result = mi.predict_role(["unknownlanguage123"], bundle)
+        assert "unknownlanguage123" not in result["top_predictive_skills"]
+
+
+# =============================================================================
+# 2. role_probabilities
+# =============================================================================
+
+class TestRoleProbabilities:
+    """
+    role_probabilities must:
+      - contain ALL role labels as keys (not just top-N)
+      - have float values in [0, 1]
+      - sum to approximately 1.0
+      - be an empty dict when source=fallback
+    """
+
+    def test_contains_all_role_labels(self):
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85)
+        result = mi.predict_role(["python"], bundle)
+        assert set(result["role_probabilities"].keys()) == set(_ROLE_LABELS)
+
+    def test_values_are_floats_in_0_1(self):
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85)
+        result = mi.predict_role(["python"], bundle)
+        for role, prob in result["role_probabilities"].items():
+            assert isinstance(prob, float), f"prob for '{role}' is not float"
+            assert 0.0 <= prob <= 1.0, f"prob for '{role}' out of range: {prob}"
+
+    def test_probabilities_sum_to_one(self):
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85)
+        result = mi.predict_role(["python"], bundle)
+        total = sum(result["role_probabilities"].values())
+        assert abs(total - 1.0) < 0.01, f"Probabilities sum to {total}, expected ~1.0"
+
+    def test_predicted_role_has_highest_probability(self):
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85, pred_idx=0)
+        result = mi.predict_role(["python"], bundle)
+        probs = result["role_probabilities"]
+        best_role = max(probs, key=probs.get)
+        assert best_role == _ROLE_LABELS[0]
+
+    def test_empty_dict_when_fallback(self):
+        mi = _reload()
+        empty_bundle = {}
+        result = mi.predict_role(["python"], empty_bundle)
+        assert result["source"] == "fallback"
+        assert result["role_probabilities"] == {}
+
+    def test_empty_dict_when_low_confidence(self):
+        """role_probabilities must still be present (not empty) when confidence is low."""
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.30, pred_idx=0)
+        result = mi.predict_role(["python"], bundle)
+        assert result["source"] == "low_confidence"
+        # Still populated — caller needs the full map to understand why confidence is low
+        assert len(result["role_probabilities"]) == _N_ROLES
+
+
+# =============================================================================
+# 3. inference_ms timing
+# =============================================================================
+
+class TestInferenceTiming:
+    """
+    inference_ms must:
+      - always be present and be a non-negative float
+      - be 0.0 on fallback path
+      - trigger a warning log when > 50 ms
+    """
+
+    def test_inference_ms_present_and_float(self):
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85)
+        result = mi.predict_role(["python"], bundle)
+        assert "inference_ms" in result
+        assert isinstance(result["inference_ms"], float)
+        assert result["inference_ms"] >= 0.0
+
+    def test_inference_ms_zero_on_fallback(self):
+        mi = _reload()
+        result = mi.predict_role(["python"], {})
+        assert result["inference_ms"] == 0.0
+
+    def test_inference_ms_logged_warning_above_50ms(self, caplog):
+        """A warning must be logged when inference_ms > 50."""
+        import logging
+        mi = _reload()
+
+        # Make predict_proba artificially slow (60 ms)
+        model = MagicMock()
+        model.predict.return_value = [0]
+
+        proba = np.array([0.85, 0.10, 0.05], dtype=np.float32)
+
+        def slow_predict_proba(_):
+            time.sleep(0.065)   # 65 ms
+            return [proba]
+
+        model.predict_proba.side_effect = slow_predict_proba
+        model.feature_importances_ = np.zeros(_N_FEATS, dtype=np.float32)
+
+        bundle = {
+            "role_predictor": model,
+            "role_config": {
+                "feature_names": _FEAT_NAMES,
+                "role_labels":   _ROLE_LABELS,
+            },
+        }
+
+        with caplog.at_level(logging.WARNING, logger="ml_inference"):
+            mi.predict_role(["python"], bundle)
+
+        warning_msgs = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        sla_warnings = [m for m in warning_msgs if "50 ms SLA" in m or "> 50 ms" in str(m)]
+        assert len(sla_warnings) >= 1, (
+            f"Expected '>50 ms SLA' warning, got: {warning_msgs}"
+        )
+
+    def test_inference_ms_no_warning_below_50ms(self, caplog):
+        """No SLA warning should appear when inference is fast (mocked)."""
+        import logging
+        mi = _reload()
+        bundle = _make_bundle(confidence=0.85)
+
+        with caplog.at_level(logging.WARNING, logger="ml_inference"):
+            mi.predict_role(["python"], bundle)
+
+        sla_warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and "50 ms" in r.message
+        ]
+        assert len(sla_warnings) == 0
+
+
+# =============================================================================
+# 4. Output schema — all new keys always present
+# =============================================================================
+
+class TestOutputSchema:
+    """
+    All three new keys (role_probabilities, top_predictive_skills, inference_ms)
+    must be present in every return dict from predict_role(), regardless of source.
+    """
+
+    _NEW_KEYS = ("role_probabilities", "top_predictive_skills", "inference_ms")
+
+    def test_ml_source_has_all_new_keys(self):
+        mi = _reload()
+        result = mi.predict_role(["python"], _make_bundle(0.85))
+        for key in self._NEW_KEYS:
+            assert key in result, f"Missing key '{key}' in ml-source result"
+
+    def test_low_confidence_has_all_new_keys(self):
+        mi = _reload()
+        result = mi.predict_role(["python"], _make_bundle(0.30))
+        assert result["source"] == "low_confidence"
+        for key in self._NEW_KEYS:
+            assert key in result, f"Missing key '{key}' in low_confidence result"
+
+    def test_fallback_has_all_new_keys(self):
+        mi = _reload()
+        result = mi.predict_role(["python"], {})
+        assert result["source"] == "fallback"
+        for key in self._NEW_KEYS:
+            assert key in result, f"Missing key '{key}' in fallback result"
+
+    def test_exception_path_has_all_new_keys(self):
+        """Even when predict() raises, the except-block must return all new keys."""
+        mi = _reload()
+        model = MagicMock()
+        model.predict.side_effect = RuntimeError("GPU error")
+        bundle = {
+            "role_predictor": model,
+            "role_config": {"feature_names": _FEAT_NAMES, "role_labels": _ROLE_LABELS},
+        }
+        result = mi.predict_role(["python"], bundle)
+        assert result["source"] == "fallback"
+        for key in self._NEW_KEYS:
+            assert key in result, f"Missing key '{key}' after exception"
+
+
+# =============================================================================
+# 5. Confidence fallback < 0.60 → "Auto Detect" (regression)
+# =============================================================================
+
+class TestConfidenceFallbackRegression:
+    """Ensure the existing confidence-gate still works with the new return shape."""
+
+    def test_below_threshold_source_is_low_confidence(self):
+        mi = _reload()
+        result = mi.predict_role(["python"], _make_bundle(0.45))
+        assert result["source"] == "low_confidence"
+
+    def test_at_threshold_source_is_ml(self):
+        mi = _reload()
+        result = mi.predict_role(["python"], _make_bundle(0.60))
+        assert result["source"] == "ml"
+
+    def test_above_threshold_source_is_ml(self):
+        mi = _reload()
+        result = mi.predict_role(["python"], _make_bundle(0.90))
+        assert result["source"] == "ml"
+
+    def test_low_confidence_predicted_role_still_present(self):
+        """Worker uses this for logging — must not be None."""
+        mi = _reload()
+        result = mi.predict_role(["python"], _make_bundle(0.45, pred_idx=1))
+        assert result["predicted_role"] == _ROLE_LABELS[1]
+
+
+# =============================================================================
+# 6. /predict-role FastAPI endpoint — smoke tests
+# =============================================================================
+
+# ── One-time stub registration ────────────────────────────────────────────────
+# bcrypt is a PyO3 C-extension that can only be initialised ONCE per Python
+# process.  Deleting and re-importing `security` between tests causes bcrypt
+# to try to re-initialise → ImportError.  The solution: register the motor /
+# database stubs in sys.modules *before* security is first imported (i.e. at
+# test-module load time), then never evict security again.
+import sys as _sys
+import types as _types
+
+def _install_db_stubs_once() -> None:
+    """Register motor / database stubs exactly once at module import time."""
+    motor_asyncio_mod = _types.ModuleType("motor.motor_asyncio")
+    motor_asyncio_mod.AsyncIOMotorClient = MagicMock()
+
+    motor_mod = _types.ModuleType("motor")
+    motor_mod.motor_asyncio = motor_asyncio_mod
+
+    db_mod = _types.ModuleType("database")
+    for _col in (
+        "users_collection",
+        "refresh_tokens_collection",
+        "analyses_collection",
+        "analysis_jobs_collection",
+        "jobs_collection",
+    ):
+        setattr(db_mod, _col, MagicMock())
+
+    for _name, _mod in {
+        "motor":               motor_mod,
+        "motor.motor_asyncio": motor_asyncio_mod,
+        "database":            db_mod,
+    }.items():
+        _sys.modules.setdefault(_name, _mod)   # only register if not already present
+
+
+_install_db_stubs_once()
+
+# Now it is safe to import security / routes once for the whole test session.
+# bcrypt initialises exactly once here; subsequent tests reuse the cached module.
+from security import get_current_user as _get_current_user  # noqa: E402
+from routes.jobs import router as _jobs_router               # noqa: E402
+
+
+class TestPredictRoleEndpoint:
+    """
+    Integration smoke tests using FastAPI's TestClient.
+
+    motor + database are stubbed at module-load time (above) so no real
+    MongoDB connection is needed.  Each test builds a fresh FastAPI app
+    with a different ml_bundle but reuses the already-imported router and
+    get_current_user dependency (so bcrypt is never re-initialised).
+    """
+
+    @staticmethod
+    def _build_client(bundle):
+        """Return a TestClient wired to the /predict-role route."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+        app.state.ml_models = bundle
+        # Bypass JWT auth — always return a dummy user
+        app.dependency_overrides[_get_current_user] = lambda: {"id": "test_user"}
+        app.include_router(_jobs_router, prefix="/api/v1")
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_returns_200_with_valid_skills(self):
+        client = self._build_client(_make_bundle(confidence=0.85))
+        resp = client.post("/api/v1/predict-role", json={"skills": ["python", "pandas"]})
+        assert resp.status_code == 200
+
+    def test_response_has_required_fields(self):
+        client = self._build_client(_make_bundle(confidence=0.85))
+        resp = client.post("/api/v1/predict-role", json={"skills": ["python", "pandas"]})
+        data = resp.json()
+        for field in (
+            "predicted_role", "confidence", "role_probabilities",
+            "top_predictive_skills", "role_alternatives", "inference_ms", "source",
+        ):
+            assert field in data, f"Missing field '{field}' in /predict-role response"
+
+    def test_low_confidence_returns_auto_detect(self):
+        client = self._build_client(_make_bundle(confidence=0.30))
+        resp = client.post("/api/v1/predict-role", json={"skills": ["python"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["predicted_role"] == "Auto Detect"
+        assert data["source"] == "low_confidence"
+
+    def test_empty_skills_returns_422(self):
+        """An empty list must fail Pydantic min_length=1 validation → 422."""
+        client = self._build_client(_make_bundle(confidence=0.85))
+        resp = client.post("/api/v1/predict-role", json={"skills": []})
+        assert resp.status_code == 422
+
+    def test_role_probabilities_is_dict(self):
+        client = self._build_client(_make_bundle(confidence=0.85))
+        resp = client.post("/api/v1/predict-role", json={"skills": ["python", "sql"]})
+        assert isinstance(resp.json()["role_probabilities"], dict)
+
+    def test_top_predictive_skills_is_list(self):
+        client = self._build_client(_make_bundle(confidence=0.85))
+        resp = client.post("/api/v1/predict-role", json={"skills": ["python", "pandas"]})
+        assert isinstance(resp.json()["top_predictive_skills"], list)
+
+    def test_503_when_bundle_is_none(self):
+        """If ML models are not loaded the endpoint must return HTTP 503."""
+        client = self._build_client(None)   # app.state.ml_models = None
+        resp = client.post("/api/v1/predict-role", json={"skills": ["python"]})
+        assert resp.status_code == 503

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -201,13 +201,17 @@ async def run_analysis(
         readiness_score = compute_readiness_score(identified_skills, missing_skills)
 
         # ── 6. ML enrichment fields ───────────────────────────────────
-        # 6a. Role confidence + alternatives
-        role_confidence  = ml_role_result.get("confidence", 0.0)
+        # 6a. Role confidence + alternatives + new interpretability fields
+        role_confidence   = ml_role_result.get("confidence", 0.0)
         role_alternatives = [
             {"role": r["role"], "confidence": r["confidence"]}
             for r in ml_role_result.get("top_roles", [])
             if r["role"] != target_role   # exclude the primary prediction
         ]
+        role_probabilities    = ml_role_result.get("role_probabilities", {})
+        top_predictive_skills = ml_role_result.get("top_predictive_skills", [])
+        role_inference_ms     = ml_role_result.get("inference_ms", 0.0)
+        logger.debug("[job=%s] role inference_ms=%.2f", job_id, role_inference_ms)
 
         # 6b. Skill categories for detected skills (Step 4 integration)
         # Uses KMeans clusterer when available, falls back to rule-based taxonomy.
@@ -237,6 +241,8 @@ async def run_analysis(
             # ML enrichment
             "role_confidence":        role_confidence,
             "role_alternatives":      role_alternatives,
+            "role_probabilities":     role_probabilities,
+            "top_predictive_skills":  top_predictive_skills,
             "skill_categories":       skill_categories,
             "missing_skills_ranked":  missing_skills_ranked,
             "model_version":          _MODEL_VERSION,
@@ -260,6 +266,8 @@ async def run_analysis(
             # ML enrichment
             "role_confidence":         role_confidence,
             "role_alternatives":       role_alternatives,
+            "role_probabilities":      role_probabilities,
+            "top_predictive_skills":   top_predictive_skills,
             "skill_categories":        skill_categories,
             "missing_skills_ranked":   missing_skills_ranked,
             "model_version":           _MODEL_VERSION,


### PR DESCRIPTION
#### **Title: Wire RF Role Predictor with Interpretability and Sync Endpoint**

#### **Description**
This PR finalizes the integration of the Random Forest role predictor into the analysis pipeline. It shifts the model from a "black box" prediction to an interpretable system by surfacing exactly which skills influenced the model's decision and providing a full probability breakdown of alternative roles.

#### **Key Enhancements**
1.  **Model Interpretability**:
    *   **`top_predictive_skills`**: Dynamically calculates which of the user's skills contributed most to the prediction using the Random Forest `feature_importances_`.
    *   **`role_probabilities`**: Returns a full dictionary of confidence scores for all supported roles, allowing the frontend to visualize the "closeness" of various career paths.
2.  **Synchronous Prediction Endpoint**:
    *   Added `POST /api/v1/predict-role`.
    *   Allows the frontend to get instant role feedback (e.g., in an onboarding wizard) without requiring a full resume upload or background job.
3.  **Performance & SLA**:
    *   Implemented wall-clock timing for inference (`inference_ms`).
    *   Added a warning logger for any inference exceeding the **50ms SLA** target.
4.  **Robust Pipeline Integration**:
    *   Updated `worker.py` to persist these new metadata fields to MongoDB.
    *   Maintains the `Auto Detect` fallback for low-confidence (<0.60) predictions.

#### **Testing & Quality**
*   **Test Suite**: Created `tests/test_role_predictor_inference.py` with 32 comprehensive test cases.
*   **Fix for PyO3/Bcrypt Error**: Implemented a specialized module-level stubbing pattern to resolve the `ImportError: PyO3 modules... may only be initialized once` issue caused by re-importing the `security` module in a test environment.
*   **Regression**: Verified existing ML fallbacks remain functional.

#### **Verification Commands**
```bash
cd backend
pytest tests/test_role_predictor_inference.py -v
```