### PR TITLE
feat(backend): implement model versioning management API with admin-p…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,3 +27,8 @@ FRONTEND_URL=http://localhost:5173
 # Maps to: backend/models/ml_models/<ML_MODEL_VERSION>/
 # Change this when you promote a new trained version (e.g. v1.1, v2.0).
 ML_MODEL_VERSION=v1.0
+
+# Admin API key for model version management.
+# Required in the X-Admin-Key header to call POST /api/v1/models/activate/:version.
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+ADMIN_API_KEY=your-admin-api-key-here

--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -1,33 +1,61 @@
 """
 routes/models.py
 ================
-Read-only API for browsing trained model version metadata.
+Model versioning management API.
 
 Endpoints
 ---------
-GET /api/v1/models/versions
-    List all available version directories with a summary of their metadata.
+GET  /api/v1/models/active
+    Returns the currently active model version (ML_MODEL_VERSION env var)
+    together with its full metadata.json and artifact inventory.
 
-GET /api/v1/models/versions/{version}
-    Return the full metadata.json + artifact inventory for a specific version.
+GET  /api/v1/models/versions
+    Lists every version directory under models/ml_models/ with a summary
+    of their metadata.json (accuracy, f1, etc.).
 
-No authentication is required — metadata.json contains only training metrics
-(no PII, no secrets).
+GET  /api/v1/models/metrics/{version}
+    Returns only the numeric metrics from metadata.json for a specific
+    version (distinct from the full-detail /versions/{version} endpoint).
+
+POST /api/v1/models/activate/{version}
+    Promotes a version to active by writing ML_MODEL_VERSION=<version>
+    to the .env file.  Requires the X-Admin-Key header.
+    Returns 202 Accepted — uvicorn --reload picks up the change automatically.
+
+Authentication
+--------------
+GET  endpoints — no authentication required (metadata contains no PII/secrets).
+POST endpoint  — requires X-Admin-Key header matching the ADMIN_API_KEY env var.
 """
 
 from __future__ import annotations
 
 import json
+import logging
+import os
+import re
 from pathlib import Path
+from typing import Any
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from security import require_admin_key
+
+logger = logging.getLogger("routes.models")
 
 router = APIRouter()
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
 
 # Resolves to: <repo>/backend/models/ml_models/
 _ML_MODELS_ROOT = (
     Path(__file__).resolve().parent.parent / "models" / "ml_models"
 )
+
+# The .env file that stores ML_MODEL_VERSION (and other server config).
+_ENV_FILE = Path(__file__).resolve().parent.parent / ".env"
+
+# ── Constants ─────────────────────────────────────────────────────────────────
 
 _REQUIRED_METADATA_FIELDS = (
     "model_name",
@@ -39,6 +67,9 @@ _REQUIRED_METADATA_FIELDS = (
     "test_samples",
     "git_commit",
 )
+
+# Metrics fields extracted from metadata.json for the /metrics endpoint.
+_METRIC_FIELDS = ("accuracy", "f1_score", "training_samples", "test_samples")
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -74,7 +105,79 @@ def _sanitize_version(version: str) -> None:
         )
 
 
+def _active_version() -> str:
+    """Return the currently active version from the ML_MODEL_VERSION env var."""
+    return (
+        os.getenv("ML_MODEL_VERSION")
+        or os.getenv("MODEL_VERSION")
+        or "v1.0"
+    )
+
+
+def _update_env_version(new_version: str) -> None:
+    """
+    Write ML_MODEL_VERSION=<new_version> into the .env file.
+
+    If the key already exists, it is replaced in-place.
+    If it doesn't exist, it is appended.
+    Raises OSError on any file I/O failure.
+    """
+    if not _ENV_FILE.exists():
+        raise OSError(f".env file not found at {_ENV_FILE}")
+
+    content = _ENV_FILE.read_text(encoding="utf-8")
+
+    # Replace existing key (handles optional surrounding whitespace / comments)
+    pattern = re.compile(r"^(ML_MODEL_VERSION\s*=\s*).*$", re.MULTILINE)
+    replacement = f"ML_MODEL_VERSION={new_version}"
+
+    if pattern.search(content):
+        new_content = pattern.sub(replacement, content)
+    else:
+        # Key absent — append it
+        new_content = content.rstrip("\n") + f"\nML_MODEL_VERSION={new_version}\n"
+
+    _ENV_FILE.write_text(new_content, encoding="utf-8")
+
+
 # ── Endpoints ─────────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/models/active",
+    summary="Get the currently active model version",
+    description=(
+        "Returns the version currently loaded by the server (read from the "
+        "``ML_MODEL_VERSION`` environment variable) together with its full "
+        "``metadata.json`` and artifact file list."
+    ),
+    tags=["Model Versioning"],
+)
+def get_active_model():
+    """Return metadata for the currently active model version."""
+    active = _active_version()
+    version_dir = _ML_MODELS_ROOT / active
+
+    if not version_dir.is_dir():
+        # Version directory is missing — return the version name but flag the issue
+        return {
+            "active_version":  active,
+            "metadata":        None,
+            "artifacts":       [],
+            "schema_complete": False,
+            "warning":         f"Version directory '{active}' does not exist on disk.",
+        }
+
+    meta = _read_metadata(version_dir)
+    artifacts = sorted(f.name for f in version_dir.iterdir() if f.is_file())
+
+    return {
+        "active_version":  active,
+        "metadata":        meta,
+        "artifacts":       artifacts,
+        "schema_complete": all(f in (meta or {}) for f in _REQUIRED_METADATA_FIELDS),
+    }
+
 
 @router.get(
     "/models/versions",
@@ -89,6 +192,7 @@ def _sanitize_version(version: str) -> None:
 )
 def list_model_versions():
     """List all available model versions with summary metadata."""
+    active = _active_version()
     versions = []
 
     for vdir in _version_dirs():
@@ -96,6 +200,7 @@ def list_model_versions():
         if meta:
             versions.append({
                 "version":          vdir.name,
+                "is_active":        vdir.name == active,
                 "model_name":       meta.get("model_name", "unknown"),
                 "training_date":    meta.get("training_date"),
                 "accuracy":         meta.get("accuracy"),
@@ -103,7 +208,6 @@ def list_model_versions():
                 "training_samples": meta.get("training_samples"),
                 "test_samples":     meta.get("test_samples"),
                 "git_commit":       meta.get("git_commit"),
-                # Flag whether the metadata meets the required schema
                 "schema_complete":  all(
                     f in meta for f in _REQUIRED_METADATA_FIELDS
                 ),
@@ -111,11 +215,141 @@ def list_model_versions():
         else:
             versions.append({
                 "version":     vdir.name,
+                "is_active":   vdir.name == active,
                 "no_metadata": True,
             })
 
-    return {"versions": versions, "count": len(versions)}
+    return {"active_version": active, "versions": versions, "count": len(versions)}
 
+
+@router.get(
+    "/models/metrics/{version}",
+    summary="Get numeric metrics for a specific model version",
+    description=(
+        "Returns only the numeric training and evaluation metrics from "
+        "``metadata.json`` for the requested version. For the full metadata "
+        "and artifact list, use ``GET /api/v1/models/versions/{version}``."
+    ),
+    tags=["Model Versioning"],
+)
+def get_model_metrics(version: str):
+    """Return training and evaluation metrics for a specific model version."""
+    _sanitize_version(version)
+
+    version_dir = _ML_MODELS_ROOT / version
+    if not version_dir.is_dir():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Version '{version}' not found.",
+        )
+
+    meta = _read_metadata(version_dir)
+    if meta is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"metadata.json not found or malformed for version '{version}'.",
+        )
+
+    # Extract top-level numeric metrics
+    metrics: dict[str, Any] = {field: meta.get(field) for field in _METRIC_FIELDS}
+
+    # Surface any nested metrics from the "extra" block (e.g. silhouette_score)
+    extra_metrics: dict[str, Any] = {}
+    if isinstance(meta.get("extra"), dict):
+        extra_metrics = meta["extra"].get("metrics", {})
+
+    return {
+        "version":        version,
+        "is_active":      version == _active_version(),
+        "model_name":     meta.get("model_name", "unknown"),
+        "training_date":  meta.get("training_date"),
+        "git_commit":     meta.get("git_commit"),
+        **metrics,
+        "extra_metrics":  extra_metrics,
+    }
+
+
+@router.post(
+    "/models/activate/{version}",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Activate a model version (admin only)",
+    description=(
+        "Promotes the specified version to active by updating ``ML_MODEL_VERSION`` "
+        "in the server's ``.env`` file. "
+        "The server will auto-reload if running with ``uvicorn --reload``. "
+        "**Requires the ``X-Admin-Key`` header.**"
+    ),
+    tags=["Model Versioning"],
+)
+async def activate_model_version(
+    version: str,
+    _: None = Depends(require_admin_key),
+):
+    """
+    Set a new active model version.
+
+    Validates that the version directory and its metadata.json exist before
+    writing to .env. Returns 202 Accepted with a reload_required flag.
+    """
+    _sanitize_version(version)
+
+    version_dir = _ML_MODELS_ROOT / version
+    if not version_dir.is_dir():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Version '{version}' not found. Available: {[d.name for d in _version_dirs()]}",
+        )
+
+    meta = _read_metadata(version_dir)
+    if meta is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Version '{version}' exists but has no valid metadata.json. "
+                "Refusing to activate an unverified model artifact."
+            ),
+        )
+
+    previous_version = _active_version()
+
+    if previous_version == version:
+        return {
+            "activated_version":  version,
+            "previous_version":   previous_version,
+            "reload_required":    False,
+            "message":            f"Version '{version}' is already active. No change made.",
+        }
+
+    try:
+        _update_env_version(version)
+        # Reload the env var in the current process so subsequent calls to
+        # _active_version() reflect the change without a restart.
+        os.environ["ML_MODEL_VERSION"] = version
+    except OSError as exc:
+        logger.error("activate_model_version: failed to update .env: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update .env file: {exc}",
+        )
+
+    logger.info(
+        "Model version activated: %s → %s (previous: %s)",
+        previous_version, version, previous_version,
+    )
+
+    return {
+        "activated_version": version,
+        "previous_version":  previous_version,
+        "reload_required":   True,
+        "message": (
+            f"Version '{version}' is now set as active in .env. "
+            "The server will auto-reload if running with --reload. "
+            "New analysis jobs will use this version after reload."
+        ),
+    }
+
+
+# ── Legacy detail endpoint (kept for backward compatibility) ──────────────────
 
 @router.get(
     "/models/versions/{version}",
@@ -145,11 +379,11 @@ def get_model_version(version: str):
             detail=f"metadata.json not found or malformed for version '{version}'.",
         )
 
-    # Artifact inventory — list all files in the versioned directory
     artifacts = sorted(f.name for f in version_dir.iterdir() if f.is_file())
 
     return {
         "version":         version,
+        "is_active":       version == _active_version(),
         "metadata":        meta,
         "artifacts":       artifacts,
         "schema_complete": all(f in meta for f in _REQUIRED_METADATA_FIELDS),

--- a/backend/security.py
+++ b/backend/security.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional, Any, Union
 import uuid
 from jose import JWTError, jwt
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 
 from dotenv import load_dotenv
@@ -125,4 +125,40 @@ async def validate_refresh_token(token: str) -> dict:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Refresh token expired or invalid",
+        )
+
+
+# ── Admin API Key dependency ──────────────────────────────────────────────────
+# Used exclusively by write-access model management endpoints
+# (e.g. POST /api/v1/models/activate/:version).
+#
+# Callers must include the header:
+#     X-Admin-Key: <value of ADMIN_API_KEY in .env>
+#
+# Returns HTTP 503 when ADMIN_API_KEY is not configured on the server,
+# and HTTP 403 when the provided key doesn't match.
+
+_ADMIN_API_KEY: str = os.getenv("ADMIN_API_KEY", "")
+
+
+async def require_admin_key(
+    x_admin_key: str = Header(..., alias="X-Admin-Key", description="Admin API key for privileged operations"),
+) -> None:
+    """
+    FastAPI dependency that enforces admin-key authentication.
+
+    Raises
+    ------
+    503  ADMIN_API_KEY env var is not set on this server.
+    403  The provided key does not match ADMIN_API_KEY.
+    """
+    if not _ADMIN_API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Admin key is not configured on this server. Set ADMIN_API_KEY in .env.",
+        )
+    if x_admin_key != _ADMIN_API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid admin key.",
         )


### PR DESCRIPTION
#### Title: `Feat: Model Versioning Management API & Admin Authentication`

#### Description
This PR implements a comprehensive model versioning management API, allowing administrators to browse trained model versions, inspect performance metrics, and promote a specific version to "active" without manual server intervention.

#### New Endpoints
| Method | Endpoint | Auth | Description |
| :--- | :--- | :--- | :--- |
| `GET` | `/api/v1/models/active` | None | Get current version and full `metadata.json`. |
| `GET` | `/api/v1/models/versions` | None | List all available version directories with an `is_active` flag. |
| `GET` | `/api/v1/models/metrics/{version}` | None | Retrieve numeric performance metrics only (accuracy, f1, etc.). |
| `POST` | `/api/v1/models/activate/{version}` | `X-Admin-Key` | Set a version as active by updating `.env` persistently. |

#### Key Features
- **Admin Authentication**: Introduced a lightweight `require_admin_key` dependency. To call the `activate` endpoint, the `X-Admin-Key` header must match the `ADMIN_API_KEY` defined in the environment.
- **Persistent Activation**: The `POST /activate` endpoint validates the version directory and its `metadata.json` before writing the new version to `.env`. 
- **Auto-Reload Compatible**: The activation flow is designed to work with `uvicorn --reload`, ensuring the server picks up the new model artifacts immediately.
- **Backward Compatibility**: Preserved the original `/versions/{version}` detail endpoint as a legacy alias.

#### Acceptance Criteria Checklist
- [x] All 4 model management endpoints implemented and documented in Swagger.
- [x] Activation endpoint strictly protected by the `X-Admin-Key` header.
- [x] Metadata is accurately parsed from version-specific `metadata.json` files.
- [x] Added `ADMIN_API_KEY` configuration to `.env` and `.env.example`.